### PR TITLE
add optional min and max y axis to affect data scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Usage
   animationTimingFunction="ease-in"
   width=500
   height=125
-  padding=10}}
+  padding=10
+  minY=0.5
+  maxY=50
+  }}
 ```
 
 * **points** - an array of values, example - `[1, 10, 45, 3, 4, 6]`.
@@ -47,6 +50,7 @@ Usage
 * **width** - A number to specify the width of the chart.
 * **height** - A number to specify the height of the chart. Optional. Defaults to `width/4`.
 * **padding** - A number to specify padding for the chart inside the SVG so that lines are not cut at the edges. Optional.
+* **minY** & **maxY** - Set the limits of the y axis. If these are undefined, they default to the smallest and largest data points respectively, which means the data is scaled to fit the graph vertically.
 
 
 

--- a/addon/components/line-graph.js
+++ b/addon/components/line-graph.js
@@ -7,6 +7,8 @@ export default Component.extend({
   layout,
   strokeWidth: 2,
   type: 'line',
+  minY: undefined,
+  maxY: undefined,
   svgWidth: computed('width', function() {
     return this.getWithDefault('width', '100%');
   }),
@@ -36,14 +38,16 @@ export default Component.extend({
       type,
       points = [],
       smoothness = 2,
-    } = this.getProperties('points', 'type', 'smoothness');
+      minY,
+      maxY
+    } = this.getProperties('points', 'type', 'smoothness', 'minY', 'maxY');
 
     if (points.length < 2) {
       return;
     }
 
     smoothness = 0.1 + (smoothness / 100);
-    return path({ points, type, smoothness });
+    return path({ points, type, smoothness, minY, maxY });
   }),
   style: computed('animation', 'animationDuration', 'animationTimingFunction', function() {
     let {

--- a/addon/utils/path.js
+++ b/addon/utils/path.js
@@ -9,7 +9,7 @@ const normalize = ({ value, min, max, scaleMin, scaleMax }) => {
   return scaleMin + (value - min) * (scaleMax - scaleMin) / (max - min);
 };
 
-const getCoordinates = (data) => {
+const getCoordinates = (data, minValue = undefined, maxValue = undefined) => {
   let minX = 10;
   let maxX = 290; // 300 - 10
   let minY = 65;  // 75 - 10
@@ -20,8 +20,15 @@ const getCoordinates = (data) => {
   // X axis is easy: just evenly-space each item in the array.
   // For the Y axis, we first need to find the min and max of our array,
   // and then normalize those values between 0 and 1.
+
+  if (minValue === undefined) {
+    minValue = Math.min(...data);
+  }
+  if (maxValue === undefined) {
+    maxValue = Math.max(...data);
+  }
   let boundariesX = { min: 0, max: data.length - 1 };
-  let boundariesY = { min: Math.min(...data), max: Math.max(...data) };
+  let boundariesY = { min: minValue, max: maxValue };
 
   let normalizedData = data.map((point, index) => ({
     x: normalize({
@@ -95,8 +102,8 @@ const bezierCommand = (point, i, a, smoothness) => {
 
 const lineCommand = point => `L ${point.x} ${point.y}`;
 
-export default function path({points, type, smoothness }) {
-  let coords = getCoordinates(points);
+export default function path({points, type, smoothness, minY, maxY}) {
+  let coords = getCoordinates(points, minY, maxY);
 
   let command = type === 'line' ? lineCommand : bezierCommand;
 


### PR DESCRIPTION
Currently data always fills the vertical height of the graph.

This PR adds an optional y axis min and max so that the scale does not change as the data changes.